### PR TITLE
Made the extension honor editor.tabSize when inserting new postings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,7 @@ function alignSingleLine(line: number) {
         wEdit.set(activeEditor.document.uri, [edit]);
         vscode.workspace.applyEdit(wEdit);
         // move cursor position
-        
+
         if (line == originalCursorPosition.line) {
             var newPosition = new Position(originalCursorPosition.line, 1 + originalCursorPosition.character + newText.length - originalLength)
             //console.log(originalCursorPosition, newPosition)
@@ -105,7 +105,7 @@ class InputCapturer {
         let line = e.contentChanges[0].range.start.line;
         if (text == "." && rangeLength == 0 && vscode.workspace.getConfiguration("beancount")["instantAlignment"]) {
             // the user just inserted a new decimal point
-            alignSingleLine(line) 
+            alignSingleLine(line)
         }
         if (text == "\n" && rangeLength == 0) {
             // the user just inserted a new line
@@ -115,11 +115,12 @@ class InputCapturer {
             if ( transArray != null ) {
                 // the user inserted a new line under a transaction
                 let r = new Range(new Position(line + 1, 0), new Position(line + 1, 0));
-                let edit = new vscode.TextEdit(r, "    ");
+                let tabSize = vscode.workspace.getConfiguration("editor")["tabSize"];
+                let edit = new vscode.TextEdit(r, ' '.repeat(tabSize));
                 let wEdit = new vscode.WorkspaceEdit();
                 wEdit.set(vscode.window.activeTextEditor.document.uri, [edit]);
                 vscode.workspace.applyEdit(wEdit); // insert four spaces for a new posting line
-            }          
+            }
         }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,7 +119,7 @@ class InputCapturer {
                 let edit = new vscode.TextEdit(r, ' '.repeat(tabSize));
                 let wEdit = new vscode.WorkspaceEdit();
                 wEdit.set(vscode.window.activeTextEditor.document.uri, [edit]);
-                vscode.workspace.applyEdit(wEdit); // insert four spaces for a new posting line
+                vscode.workspace.applyEdit(wEdit); // insert spaces for a new posting line
             }
         }
     }


### PR DESCRIPTION
When inserting new lines under a transaction the extension automatically adds some spaces. This is nice, but I have my editor set to use 2 as the tabSize and it would be nice if the extension honored that setting.

I just realised that these diffs contain more changes than they should. This is because my editor automatically trims whitespace at the end of a line and I forgot about that before I committed. Please let me know if this is a problem.