### PR TITLE
Using beancount-language-server to provide better completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Set to true to align the amount (like 1.00 BTC) once a decimal point is inserted."
+                },
+                "beancount.beanQuery":{
+                    "type": "string",
+                    "default": "/usr/local/bin/bean-query",
+                    "description": "Path to the bean-query executable to use to provide completions"
                 }
             }
         },
@@ -57,7 +62,7 @@
     },
     "dependencies": {
         "vscode-languageclient": "^3.2.0",
-        "beancount-language-server": "^1.0.0"
+        "beancount-language-server": "^1.1.0"
     },
     "devDependencies": {
         "typescript": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "node ./node_modules/vscode/bin/test"
     },
+    "dependencies": {
+        "vscode-languageclient": "^3.2.0",
+        "beancount-language-server": "^1.0.0"
+    },
     "devDependencies": {
         "typescript": "^2.0.3",
         "vscode": "^1.0.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,8 @@ export function activate(context: vscode.ExtensionContext) {
     let clientOptions: LanguageClientOptions = {
         documentSelector: ['beancount'],
         synchronize: {
-            fileEvents: vscode.workspace.createFileSystemWatcher('**/.clientrc')
+            fileEvents: vscode.workspace.createFileSystemWatcher('**/.clientrc'),
+            configurationSection: 'beancount.beanQuery'
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,13 +2,15 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
-import { Position, Range} from 'vscode';
+import { Position, Range } from 'vscode';
+import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, TransportKind } from 'vscode-languageclient';
+import * as path from 'path';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 
-    vscode.commands.registerCommand('beancount.alignCommodity',()=>{
+    vscode.commands.registerCommand('beancount.alignCommodity', () => {
         // Align commodity for all lines
         let lc = vscode.window.activeTextEditor.document.lineCount;
         for (var i = 0; i < lc; i++) {
@@ -19,7 +21,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
     })
 
-    vscode.commands.registerCommand('beancount.insertDate', ()=>{
+    vscode.commands.registerCommand('beancount.insertDate', () => {
         const today = new Date();
         let year = today.getFullYear().toString();
         let month = (today.getMonth() + 1 < 10 ? "0" : "") + (today.getMonth() + 1).toString();
@@ -35,6 +37,22 @@ export function activate(context: vscode.ExtensionContext) {
 
     let inputCapturer = new InputCapturer()
     context.subscriptions.push(inputCapturer);
+
+    let serverModule = context.asAbsolutePath(path.join('./node_modules', 'beancount-language-server', 'dist', 'server.js'));
+    let debugOptions = { execArgv: ["--nolazy", "--debug=6009"] };
+    let serverOptions: ServerOptions = {
+        run: { module: serverModule, transport: TransportKind.ipc },
+        debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
+    }
+    let clientOptions: LanguageClientOptions = {
+        documentSelector: ['beancount'],
+        synchronize: {
+            fileEvents: vscode.workspace.createFileSystemWatcher('**/.clientrc')
+        }
+    }
+
+    let client = new LanguageClient('Beancount', serverOptions, clientOptions).start();
+    context.subscriptions.push(client);
 }
 
 function alignSingleLine(line: number) {
@@ -62,7 +80,7 @@ function alignSingleLine(line: number) {
     let whiteLength = targetDotPosition - contentBefore.length - (amountArray[0].length - 1)
     if (whiteLength > 0) {
         let newText = contentBefore + (new Array(whiteLength + 1).join(' ')) + amountArray[0] + contentAfterAmount
-        let r = new vscode.Range(new Position(line,0), new Position(line, originalText.length))
+        let r = new vscode.Range(new Position(line, 0), new Position(line, originalText.length))
         let edit = new vscode.TextEdit(r, newText)
         let wEdit = new vscode.WorkspaceEdit();
         wEdit.set(activeEditor.document.uri, [edit]);
@@ -112,7 +130,7 @@ class InputCapturer {
             let lineText = vscode.window.activeTextEditor.document.lineAt(line).text
             let transRegex = /([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2}) (\*|\!)/
             let transArray = transRegex.exec(lineText)
-            if ( transArray != null ) {
+            if (transArray != null) {
                 // the user inserted a new line under a transaction
                 let r = new Range(new Position(line + 1, 0), new Position(line + 1, 0));
                 let tabSize = vscode.workspace.getConfiguration("editor")["tabSize"];


### PR DESCRIPTION
I wanted to have better completions than the default one provided by Visual Studio code and I came up with [a language server](https://github.com/mariosangiorgio/beancount-language-server) that is aware of narrations and accounts and tries to provide context aware suggestions.

The code is a bit rough (it calls `bean-query` to retrieve the information it needs) but it might be a good starting point. For now it also uses some heuristics instead of doing a full parsing and has some todos that should be sorted out before using it in production.

I think this could be good enough as a proof of concept so I'd like to know what you think about it and if you think this is something that could add value to the extension once it gets polished.