### PR TITLE
protect against empty contentChanges arrays

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,6 +91,10 @@ export function activate(context: vscode.ExtensionContext) {
     }))
 
     context.subscriptions.push(vscode.workspace.onDidChangeTextDocument((e:vscode.TextDocumentChangeEvent)=>{
+        if (e.contentChanges.length == 0) {
+            //protect against empty contentChanges arrays...
+            return;
+        }
         let text = e.contentChanges[0].text;
         let rangeLength = e.contentChanges[0].rangeLength;
         let line = e.contentChanges[0].range.start.line;


### PR DESCRIPTION
The extension wasn't functioning correctly for me. I tracked it down to the fact that it was regularly receiving a TextDocumentChangeEvent with an empty contentChanges array. This change just bails out if an empty contentChanges array is passed in...