### PR TITLE
ensure workspace folder is the working directory

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { Position, Range} from 'vscode';
 import { spawn } from 'child_process';
 import { existsSync } from 'fs';
+import { chdir } from 'process';
 import * as opn from 'opn'
 
 // this method is called when your extension is activated
@@ -125,6 +126,7 @@ export function activate(context: vscode.ExtensionContext) {
         if(vscode.window.activeTextEditor.document.languageId != 'beancount') {
             return
         }
+        chdir(vscode.workspace.workspaceFolders[0].uri.path);
         if (existsSync(vscode.workspace.getConfiguration("beancount")["mainBeanFile"])) {
             mainBeanFile = vscode.workspace.getConfiguration("beancount")["mainBeanFile"]
         }


### PR DESCRIPTION
I had the 'mainBeanFile' setting set to my main beancount file, 'main.bean', but the other files were being checked as though the setting was blank. It turns out that the existsSync call was returning false because the current working directory was "/". This change ensures that the current working directory is set to the first folder in the workspace, so the filename reference in 'mainBeanFile' is relative. This could have been because I'm running on a Mac (MacOS 10.13.4)? Anyway, it works for me now.