### PR TITLE
Add code folding markers

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -26,5 +26,12 @@
         ["\"", "\""],
         ["'", "'"]
     ],
+    "folding": {
+        "offSide": false,
+        "markers": {
+            "start": ";#region",
+            "end": ";#endregion"
+        }
+    },
     "wordPattern": "[\\w:-]+|[\\d.]+|[\\d-/]|(\"[\\w- ]+\")"
 }


### PR DESCRIPTION
Following the recommendations [here](https://code.visualstudio.com/updates/v1_17#_folding-regions), it seems like `;#region` fits the best.

Since [lines with non-valid beancount syntax are ignored](https://docs.google.com/document/d/1wAMVrKIA2qtRGmoVDSUBJGmYZSygUaR0uOMW1GV3YE0/edit#heading=h.9zjhwskw53j8), one alternative would be to directly use `#region`. However, using explicit comments seems cleaner to me and provides better syntax highlighting (if going down this route, new syntax highlighting could be added).

See: https://code.visualstudio.com/docs/extensionAPI/extension-points#_contributeslanguages
Fixes #5