### PR TITLE
Recognize indented directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Simple [Beancount](http://furius.ca/beancount/) support for VSCode
 4. Auto balance checking after saving files
 5. Hovers with account balances.
 6. Code snippets ([@vlamacko](https://github.com/Lencerf/vscode-beancount/pull/7))
+7. Region folding - use indentation (#5), or special comments (#11)
 
 ## Extension Settings
 

--- a/syntaxes/beancount.tmLanguage
+++ b/syntaxes/beancount.tmLanguage
@@ -20,7 +20,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^(poptag|pushtag)\s+(#)([A-Za-z0-9\-_/.]+)</string>
+			<string>^\s*(poptag|pushtag)\s+(#)([A-Za-z0-9\-_/.]+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -59,7 +59,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^(include)\s+(\".*\")</string>
+			<string>^\s*(include)\s+(\".*\")</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -93,7 +93,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^(option)\s+(\".*\")\s+(\".*\")</string>
+			<string>^\s*(option)\s+(\".*\")\s+(\".*\")</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -132,7 +132,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^(plugin)\s+(\"(.*)\")\s+(\".*\")</string>
+			<string>^\s*(plugin)\s+(\"(.*)\")\s+(\".*\")</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
When using region folding through indentation in VSCode, this extension didn't recognize directives, because the language grammar explicitly looked for the start of the line. I'm allowing whitespace since beancount itself supports it (I've been using it with my personal ledger).

Also documented the folding syntax from the `README` for others starting out.