### PR TITLE
Add warning messages for flagged items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "beancount",
-    "version": "0.3.0",
+    "version": "0.3.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "beancount",
     "displayName": "Beancount",
     "description": "VSCode extension for Beancount",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "publisher": "Lencerf",
     "engines": {
         "vscode": "^1.23.0"
@@ -55,6 +55,21 @@
                     "type": "string",
                     "default": "python3",
                     "description": "Specify the path of Python if beancount is not installed in the main Python installation."
+                },
+                "beancount.flagWarnings": {
+                    "type":"object",
+                    "default":{
+                        "*": null,
+                        "!": 1,
+                        "P": null,
+                        "S": null,
+                        "T": null,
+                        "C": null,
+                        "U": null,
+                        "R": null,
+                        "M": null
+                    },
+                    "description": "Provide a map from flag value (a string) to VS Code severity level, or null to not show a warning for this flag."
                 }
             }
         },


### PR DESCRIPTION
This adds warnings in the VSCode "problems" pane for flagged transactions/postings. The severity level is customizable per flag, and includes an option to disable warnings for a particular flag. By default only the warning flag (`!`) results in a warning, at the "warning" level in VSCode.