### PR TITLE
Make formatter aware of language specific tabSize settings

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -26,7 +26,7 @@ export class Formatter {
             if ( transArray != null ) {
                 // the user inserted a new line under a transaction
                 let r = new Range(new Position(line + 1, 0), new Position(line + 1, 0));
-                let tabSize = vscode.workspace.getConfiguration("editor")["tabSize"];
+                let tabSize = <number> vscode.window.activeTextEditor.options.tabSize;
                 let edit = new vscode.TextEdit(r, ' '.repeat(tabSize));
                 let wEdit = new vscode.WorkspaceEdit();
                 wEdit.set(vscode.window.activeTextEditor.document.uri, [edit]);


### PR DESCRIPTION
Previously the formatter uses global `editor.tabSize` as tab size, and ignores language specific settings such as `"[beancount]": {"editor.tabSize": 2}`. This update makes formatter use the correct `tabSize` for the currently active editor.