### PR TITLE
Support relative path to python (to allow wrapper scripts)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,12 +102,13 @@ export class Extension {
             pyArgs.push("--payeeNarration")
         }
         this.logger.appendLine(`running ${python3Path} ${pyArgs} to refresh data...`)
+        let cwd = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : undefined;
         run_cmd(python3Path, pyArgs, (text: string) => {
             const errors_completions = text.split('\n', 3)
             this.provideDiagnostics(errors_completions[0], errors_completions[2])
             this.completer.updateData(errors_completions[1])
             this.logger.appendLine("Data refreshed.")
-        });
+        }, cwd? {cwd} : undefined, str => this.logger.append(str));
     }
 
     provideDiagnostics(errors_json: string, flags_json: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,11 @@
-import { spawn } from 'child_process';
+import { spawn, SpawnOptions } from 'child_process';
 
-export function run_cmd(cmd:string, args:Array<string>, callBack: (stdout: string) => void) {
-    var child = spawn(cmd, args);
+export function run_cmd(cmd: string, args: Array<string>, callBack: (stdout: string) => void, options?: SpawnOptions, logger?: (str: string) => void) {
+    var child = spawn(cmd, args, options);
+    if (logger) {
+        child.on('error', (e) => logger("error: " + e))
+        child.stderr.on('data', (e) => logger("stderr: " + e));
+    }
     var resp = "";
     child.stdout.on('data', function (buffer) { resp += buffer.toString() });
     child.stdout.on('end', function() { callBack (resp) });


### PR DESCRIPTION
This PR allows configuring a workspace relative path to python.

I don't have Beancount installed globally, but use https://direnv.net together with https://nixos.org/nixpkgs/ to handle project dependencies.

Beancount + Fava are packaged with a nix-generated python wrapper script, that includes all the `PYTHONPATH` variables etc. so that python can find all library dependencies.

I tried to make vscode-beancount run this script  and discovered it does not `spawn` from workspace. This PR fixes that.