### PR TITLE
Syntax Highlight Enhancement

### DIFF
--- a/syntaxes/beancount.tmLanguage
+++ b/syntaxes/beancount.tmLanguage
@@ -176,7 +176,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s+(open|close|pad|custom)</string>
+			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s+(open|close|pad)\b</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -239,6 +239,88 @@
 					<string>\,</string>
 					<key>name</key>
 					<string>punctuation.separator.beancount</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#illegal</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s+(custom)\b</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.year.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.beancount</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.month.beancount</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.beancount</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.date.day.beancount</string>
+				</dict>
+				<key>6</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.beancount</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Custom directive</string>
+			<key>end</key>
+			<string>(?=(^\s*$|^\S))</string>
+			<key>name</key>
+			<string>meta.directive.dated.beancount</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#meta</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#string</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#bool</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#amount</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#number</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#date</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#account</string>
 				</dict>
 				<dict>
 					<key>include</key>

--- a/syntaxes/beancount.tmLanguage
+++ b/syntaxes/beancount.tmLanguage
@@ -570,7 +570,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s+(txn|[*!&amp;amp;#?%PSTCURM])(?:\s+(".*")(?=\s+"))?\s+(".*?")(?=((?:\s+#[a-zA-z\-]+(?=\s))*(?:\s+\^[a-zA-z\-\.]+(?=\s))*(?:\s+;\s*.*)?)\s)</string>
+			<string>([0-9]{4})([\-|/])([0-9]{2})([\-|/])([0-9]{2})\s*(txn|[*!&amp;#?%PSTCURM])\s*(".*?")?\s*(".*?")?</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -837,7 +837,7 @@
 		<key>flag</key>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;=\s)([*!&amp;amp;#?%PSTCURM])(?=\s+)</string>
+			<string>(?&lt;=\s)([*!&amp;#?%PSTCURM])(?=\s+)</string>
 			<key>name</key>
 			<string>keyword.other.beancount</string>
 		</dict>

--- a/syntaxes/beancount.tmLanguage
+++ b/syntaxes/beancount.tmLanguage
@@ -708,6 +708,47 @@
 				</dict>
 			</array>
 		</dict>
+		<key>bool</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>constant.language.bool.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.currency.beancount</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>entity.type.commodity.beancount</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>TRUE|FALSE</string>
+		</dict>
+		<key>number</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.modifier.beancount</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.currency.beancount</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>([\-|\+]?)(\d+(?:,\d{3})*(?:\.\d*)?)</string>
+		</dict>
 		<key>amount</key>
 		<dict>
 			<key>captures</key>
@@ -729,7 +770,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>([\-|\+]?)((?:\d|\d[\d,]*\d)(?:\.\d*)?)\s*([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])</string>
+			<string>([\-|\+]?)(\d+(?:,\d{3})*(?:\.\d*)?)\s*([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])</string>
 			<key>name</key>
 			<string>meta.amount.beancount</string>
 		</dict>
@@ -869,7 +910,7 @@
 		<key>meta</key>
 		<dict>
 			<key>begin</key>
-			<string>^\s*([a-z][A-Za-z0-9\-]+)([:])\s</string>
+			<string>^\s*([a-z][A-Za-z0-9\-_]+)([:])</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -892,6 +933,34 @@
 				<dict>
 					<key>include</key>
 					<string>#string</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#account</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#bool</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#commodity</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#date</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#tag</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#amount</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#number</string>
 				</dict>
 				<dict>
 					<key>include</key>

--- a/syntaxes/beancount.tmLanguage
+++ b/syntaxes/beancount.tmLanguage
@@ -132,7 +132,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^\s*(plugin)\s+(\"(.*)\")\s+(\".*\")</string>
+			<string>^\s*(plugin)\s*("(.*?)")\s*(".*?")?</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/syntaxes/beancount.tmLanguage
+++ b/syntaxes/beancount.tmLanguage
@@ -744,7 +744,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(?&lt;=\s)(;.*)(?=\n)</string>
+			<string>(;.*)$</string>
 		</dict>
 		<key>commodity</key>
 		<dict>
@@ -864,7 +864,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(?&lt;=\s)(\^)([A-Za-z0-9\-_/.]+)(?=\s)</string>
+			<string>(\^)([A-Za-z0-9\-_/.]+)</string>
 		</dict>
 		<key>meta</key>
 		<dict>
@@ -1013,7 +1013,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(?&lt;=\s)(#)([A-Za-z0-9\-_/.]+)(?=\s)</string>
+			<string>(#)([A-Za-z0-9\-_/.]+)</string>
 		</dict>
 	</dict>
 	<key>scopeName</key>


### PR DESCRIPTION
## Changes
This PR adds support to the following syntax:
* `plugin` without arguments
* `transaction` without payee or narration
* tag, link and comment without preceding spaces
* meta key with underscore
* meta values of various types
* `custom` with arguments of various types

It also fixes some minor problems:
* escapes `&` in syntax file as `&amp;` instead of the original `&amp;amp;`
* disallows `2019-01-01 padAssets:Foo` (without space between directive and account)

## Testing
It doesn't seem quite testable so only some manual testing. Might not be sufficient.

## Preview
### Before
![before](https://user-images.githubusercontent.com/3611446/64924177-34e6d780-d814-11e9-962f-b9691326de80.png)
### After
![after](https://user-images.githubusercontent.com/3611446/64924374-990a9b00-d816-11e9-8465-a59490e0849b.png)
