### PR TITLE
chage assets-class to asset-class

### DIFF
--- a/snippets/beancount.json
+++ b/snippets/beancount.json
@@ -31,7 +31,7 @@
 		"body": [
 			"${1:$CURRENT_YEAR}-${2:$CURRENT_MONTH}-${3:$CURRENT_DATE} commodity ${4:ISO/Ticker}",
             "  name: \"${5:FullName}\"",
-            "  assets-class: \"${6|cash,stock|}\"",
+            "  asset-class: \"${6|cash,stock|}\"",
             "$0"
 		],
 		"description": "Add a commodity metadata (optional)."


### PR DESCRIPTION
According to the manual of beancount, the commidity meta data `assets-class` should be `asset-class` 
https://beancount.github.io/docs/beancount_language_syntax.html#commodity