### PR TITLE
Add Inlay Hints for last legs of transactions with elided amounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,11 @@
             "M": null
           },
           "description": "Provide a map from flag value (a string) to VS Code severity level, or null to not show a warning for this flag."
+        },
+        "beancount.inlayHints": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show value inferred by beancount when the amount is not specified in the last leg of the transaction"
         }
       }
     },

--- a/pythonFiles/beancheck.py
+++ b/pythonFiles/beancheck.py
@@ -64,7 +64,7 @@ for entry in entries:
             if hasattr(posting, 'flag') and posting.flag == "!":
                 flagged_entries.append(get_flag_metadata(posting))
             if posting.meta and posting.meta.get('__automatic__', False) is True:
-                automatics[posting.meta['filename']][int(posting.meta['lineno'])] = posting.units.to_string()
+                automatics[posting.meta['filename']][posting.meta['lineno']] = posting.units.to_string()
     elif isinstance(entry, Open):
         accounts[entry.account] = {
             'open': entry.date.__str__(),

--- a/pythonFiles/beancheck.py
+++ b/pythonFiles/beancheck.py
@@ -107,8 +107,8 @@ output['payees'] = list(payees)
 output['narrations'] = list(narrations)
 output['tags'] = list(tags)
 output['links'] = list(links)
-output['automatics'] = automatics
 
 print(json.dumps(error_list))
 print(json.dumps(output))
 print(json.dumps(flagged_entries))
+print(json.dumps(automatics))

--- a/pythonFiles/beancheck.py
+++ b/pythonFiles/beancheck.py
@@ -59,12 +59,16 @@ for entry in entries:
                 narrations.add(f'{entry.narration}')
             tags.update(entry.tags)
             links.update(entry.links)
+        txn_commodities = set()
         for posting in entry.postings:
-            commodities.add(posting.units.currency)
+            txn_commodities.add(posting.units.currency)
             if hasattr(posting, 'flag') and posting.flag == "!":
                 flagged_entries.append(get_flag_metadata(posting))
             if posting.meta and posting.meta.get('__automatic__', False) is True:
-                automatics[posting.meta['filename']][posting.meta['lineno']] = posting.units.to_string()
+                # only send the posting if more than 2 legs in txn, or multiple commodities
+                if len(entry.postings) > 2 or len(txn_commodities) > 1:
+                    automatics[posting.meta['filename']][posting.meta['lineno']] = posting.units.to_string()
+        commodities.update(txn_commodities)
     elif isinstance(entry, Open):
         accounts[entry.account] = {
             'open': entry.date.__str__(),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -218,10 +218,11 @@ export class Extension {
       python3Path,
       pyArgs,
       (text: string) => {
-        const errorsCompletions = text.split("\n", 3);
+        const errorsCompletions = text.split("\n", 4);
         this.provideDiagnostics(errorsCompletions[0], errorsCompletions[2]);
         this.completer.updateData(errorsCompletions[1]);
         this.logger.appendLine("Data refreshed.");
+        this.hintUpdater.updateData(errorsCompletions[3]);
       },
       cwd ? { cwd } : undefined,
       (str) => this.logger.append(str)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { Formatter } from "./formatter";
 import { runCmd } from "./utils";
 import { SymbolProvider } from "./symbolProvider";
 import DocumentLinkProvider from "./documentLinkProvider";
+import { HintsUpdater } from "./inlayHints";
 
 export function activate(context: vscode.ExtensionContext) {
   const extension = new Extension(context);
@@ -104,6 +105,7 @@ export class Extension {
   diagnosticCollection: vscode.DiagnosticCollection;
   formatter: Formatter;
   logger: vscode.OutputChannel;
+  hintUpdater: HintsUpdater;
   flagWarnings: FlagWarnings;
   context: vscode.ExtensionContext;
   symbolProvider: SymbolProvider;
@@ -112,6 +114,7 @@ export class Extension {
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
     this.completer = new Completer(this);
+    this.hintUpdater = new HintsUpdater(this);
     this.actionProvider = new ActionProvider();
     this.favaManager = new FavaManager(this);
     this.diagnosticCollection =

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -221,7 +221,6 @@ export class Extension {
         const errorsCompletions = text.split("\n", 4);
         this.provideDiagnostics(errorsCompletions[0], errorsCompletions[2]);
         this.completer.updateData(errorsCompletions[1]);
-        this.logger.appendLine("Data refreshed.");
         this.hintUpdater.updateData(errorsCompletions[3]);
       },
       cwd ? { cwd } : undefined,

--- a/src/inlayHints.ts
+++ b/src/inlayHints.ts
@@ -52,6 +52,9 @@ export class HintsUpdater {
     }
 
     private renderDecorations(editor: vscode.TextEditor) {
+        if (!vscode.workspace.getConfiguration("beancount")["inlayHints"]) {
+            return;
+        }
         const file = editor.document.fileName;
         this.extension.logger.appendLine(`Rendering hints for ${file}`);
 

--- a/src/inlayHints.ts
+++ b/src/inlayHints.ts
@@ -1,0 +1,67 @@
+import * as vscode from 'vscode';
+import { Extension } from './extension';
+
+interface InlayHintStyle {
+    decorationType: vscode.TextEditorDecorationType;
+    decorationOptions: vscode.DecorationOptions;
+};
+type Automatics = { [file: string]: { [line: string]: string } };
+
+export class HintsUpdater implements vscode.Disposable {
+    automatics: Automatics = {};
+    extension: Extension;
+    constructor(extension: Extension) {
+        this.extension = extension;
+    }
+
+    updateData(data: string) {
+        this.extension.logger.appendLine("Got data");
+        this.automatics = JSON.parse(data).automatics;
+        this.renderDecorations();
+    }
+
+    private getCurrencyCol(linetext: string) {
+        this.extension.logger.appendLine(linetext);
+        let res = linetext.match(/\s*(\S+)\s+(?<amount>[0-9.\-]+)(?<whitespace>\s*)(?<currency>\S+)/);
+        let amt = res?.groups?.amount;
+        if (!amt)
+            return undefined;
+
+        return { pos: linetext.indexOf(amt), amount: res?.groups?.amount ?? "", whitespace: res?.groups?.whitespace ?? "", currency: res?.groups?.currency ?? "" };
+    }
+
+    private padAmount(prevLine: string, curLine: string, units: string) {
+        const groups = this.getCurrencyCol(prevLine);
+        if (!groups)
+            return units;
+        const endpos = groups.pos + groups.amount.length + groups.whitespace.length;
+        const SPACE = '\u00a0';
+        return units.padStart(endpos - curLine.length + units.split(" ")[1].length, SPACE);
+    }
+
+    renderDecorations() {
+        let file = vscode.window.activeTextEditor?.document.fileName;
+        if (!file)
+            return;
+        let doc = vscode.window.activeTextEditor?.document;
+        if (!doc)
+            return;
+
+        for (const [lineno, units] of Object.entries(this.automatics[file])) {
+            let line = doc.lineAt((+lineno) - 1);
+            let prevLine = doc.lineAt((+lineno) - 2);
+            let text = this.padAmount(prevLine.text, line.text, units);
+            let dt = vscode.window.createTextEditorDecorationType({
+                ["after"]: {
+                    color: "#aaa",
+                    fontStyle: "normal",
+                    contentText: text,
+                }
+            });
+            vscode.window.activeTextEditor?.setDecorations(dt, [line.range]);
+        }
+    }
+    dispose() {
+
+    }
+}

--- a/src/inlayHints.ts
+++ b/src/inlayHints.ts
@@ -2,10 +2,6 @@ import assert = require('assert');
 import * as vscode from 'vscode';
 import { Extension } from './extension';
 
-interface InlayHintStyle {
-    decorationType: vscode.TextEditorDecorationType;
-    decorationOptions: vscode.DecorationOptions;
-};
 type Automatics = { [file: string]: { [line: string]: string } };
 
 const HINT_DECO = vscode.window.createTextEditorDecorationType({

--- a/src/inlayHints.ts
+++ b/src/inlayHints.ts
@@ -30,7 +30,7 @@ export class HintsUpdater {
 
     updateData(data: string) {
         this.extension.logger.appendLine("Got data");
-        this.automatics = JSON.parse(data).automatics;
+        this.automatics = JSON.parse(data);
         vscode.window.visibleTextEditors.filter(this.isTrackedEditor, this).forEach(this.renderDecorations, this);
     }
 

--- a/src/inlayHints.ts
+++ b/src/inlayHints.ts
@@ -66,7 +66,7 @@ export class HintsUpdater {
                     break;
                 }
                 dotPos = this.getDotPos(prevLine.text);
-                if (dotPos !== undefined) {
+                if (dotPos !== null) {
                     break;
                 };
             }

--- a/src/inlayHints.ts
+++ b/src/inlayHints.ts
@@ -1,4 +1,3 @@
-import assert = require('assert');
 import * as vscode from 'vscode';
 import { Extension } from './extension';
 
@@ -25,7 +24,6 @@ export class HintsUpdater {
     }
 
     updateData(data: string) {
-        this.extension.logger.appendLine("Got data");
         this.automatics = JSON.parse(data);
         vscode.window.visibleTextEditors.filter(this.isTrackedEditor, this).forEach(this.renderDecorations, this);
     }
@@ -48,7 +46,7 @@ export class HintsUpdater {
         return units.padStart(endpos - curLine.length + units.split(" ")[1].length, SPACE);
     }
 
-    private onDidChangeVisibleTextEditors(e: vscode.TextEditor[]) {
+    private onDidChangeVisibleTextEditors(e: readonly vscode.TextEditor[]) {
         this.extension.logger.appendLine(`Changed visible text editors`);
         // if there is any tracked beancount file open
         e.filter(this.isTrackedEditor, this).forEach(this.renderDecorations, this);
@@ -59,7 +57,6 @@ export class HintsUpdater {
         this.extension.logger.appendLine(`Rendering hints for ${file}`);
 
         const hints = Object.entries(this.automatics[file]).map(([lineno, units]) => {
-            assert(editor);
             const line = editor.document.lineAt((+lineno) - 1);
             const prevLine = editor.document.lineAt((+lineno) - 2);
             const contentText = this.padAmount(prevLine.text, line.text, units);


### PR DESCRIPTION
In some complicated transactions where I have not specified the amount in the last leg of the transaction, I still want to view the value that beancount has inferred.

This PR adds support for exactly this scenario by adding inlay hints for such postings.
![Screenshot_20220213_231003](https://user-images.githubusercontent.com/29517049/153767434-95eadf66-5c77-4d84-8d4b-f83e2eb0610d.png)

It only adds the hints for non-trivial transactions, which are either:
1. Transctions with more than two legs
2. Transactions dealing with multiple commodities

(Open to suggestions on more scenarios)

The extension does not actually calculate the balance amount, so the inlay hints are not real-time. They will show up only after a `bean-check` run on the file(s), usually triggered by a file save.

TODO:
- [x] Add config to disable the hints
  - [ ] Also, a config to change the colors of the inlay hints
  - [ ] And a config to show hints even for trivial transactions 
- [ ] More robust column alignment for the inlaid amount.
  - [x] ~Currently, it only checks the previous line and tries to match its alignment. This means if there's a comment instead of a posting on the previous line, it will fail to get the correct column.~ Fixed. Now we keep searching in previous lines to find the pad amount.
  - [x] Needs more testing