### PR TITLE
Skip closed accounts when prompting complete items

### DIFF
--- a/src/completer.ts
+++ b/src/completer.ts
@@ -273,12 +273,16 @@ implements vscode.CompletionItemProvider, vscode.HoverProvider {
               position,
               this.wordPattern,
           );
-          for (const account of Object.keys(this.accounts)) {
+          for (const accountName of Object.keys(this.accounts)) {
+            const account = this.accounts[accountName];
+            if (account.close !== null && account.close !== '') {
+              continue;
+            }
             const item = new CompletionItem(
-                account,
+                accountName,
                 CompletionItemKind.EnumMember,
             );
-            item.documentation = this.describeAccount(account);
+            item.documentation = this.describeAccount(accountName);
             item.range = wordRange;
             list.push(item);
           }


### PR DESCRIPTION
Fix the issue #68 by skipping the closed account.

Verified in my environment with below test file:
```beancount
2022-01-29 open Assets:Test1 USD
2022-01-29 open Assets:Test2 USD
2022-01-30 close Assets:Test1

2022-01-31 * "Test"
    Asset
```

Verify result:
![image](https://user-images.githubusercontent.com/4214297/160284380-3b8689b1-d198-4999-9175-7f4944decaf3.png)
