### PR TITLE
"Input Method" Support on Account Name

### DIFF
--- a/src/inputMethods/inputMethod.ts
+++ b/src/inputMethods/inputMethod.ts
@@ -1,3 +1,7 @@
 export interface InputMethod {
-  getLetterRepresentation(w: string): string;
+  getLetterRepresentation(w: string, config?: InputMethodConfig): string;
+}
+
+export class InputMethodConfig {
+  keepPunctuation: boolean = false;
 }

--- a/src/inputMethods/pinyin.ts
+++ b/src/inputMethods/pinyin.ts
@@ -1,4 +1,4 @@
-import {InputMethod} from './inputMethod';
+import {InputMethod, InputMethodConfig} from './inputMethod';
 import {readFileSync} from 'fs';
 
 export class Pinyin implements InputMethod {
@@ -14,14 +14,16 @@ export class Pinyin implements InputMethod {
     }
   }
 
-  getLetterRepresentation(w: string): string {
+  getLetterRepresentation(w: string, config?: InputMethodConfig): string {
+    const punctuationReg = /[,.\:\-\\/!?]/i;
     const reg = /[0-9a-zA-Z]/i;
     const result = [];
     for (let str of w) {
       if (!str.match(reg)) {
-        str = this._pyData.get(str) || '';
+        let defatultStr = config?.keepPunctuation && str.match(punctuationReg) ? str : '';
+        str = this._pyData.get(str) || defatultStr;
       }
-      result.push(str)
+      result.push(str);
     }
     return result.join('');
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,3 +24,10 @@ export function runCmd(
 export function countOccurrences(s: string, c: RegExp) {
   return (s.match(c) || []).length;
 }
+
+export function pushIfEmpty <T> (array: T[], defaultValue: T) : T[] {
+  if (array.length === 0) {
+    array.push(defaultValue);
+  }
+  return array;
+}


### PR DESCRIPTION
This PR extends the "input method" feature to acount name so that input of acount name can be benifited from current pinyin support on "payee" input.

![image](https://user-images.githubusercontent.com/34705216/183009099-9c1badd5-12dc-4ffb-8a29-f17ed8f5698d.png)

