### PR TITLE
fix(syntax): "name" in "entity.name.type"

### DIFF
--- a/syntaxes/beancount.tmLanguage
+++ b/syntaxes/beancount.tmLanguage
@@ -920,7 +920,7 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>entity.type.commodity.beancount</string>
+					<string>entity.name.type.commodity.beancount</string>
 				</dict>
 			</dict>
 			<key>match</key>
@@ -961,7 +961,7 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>entity.type.commodity.beancount</string>
+					<string>entity.name.type.commodity.beancount</string>
 				</dict>
 			</dict>
 			<key>match</key>
@@ -987,7 +987,7 @@
 			<key>match</key>
 			<string>([A-Z][A-Z0-9\'\.\_\-]{0,22}[A-Z0-9])</string>
 			<key>name</key>
-			<string>entity.type.commodity.beancount</string>
+			<string>entity.name.type.commodity.beancount</string>
 		</dict>
 		<key>cost</key>
 		<dict>


### PR DESCRIPTION
Let's fix the scope name, because
- none of most popular dark themes has a theme selector for `entity.type.*`, but rather every theme has a selector for a `entity.name.type.*`.
- the two guides linked in vscode scoping docs ([1](https://macromates.com/manual/en/language_grammars), [2](https://www.sublimetext.com/docs/scope_naming.html)) suggest to use `entity.name.type`

| before (dark modern theme) | after (dark modern theme) |
|--------|--------|
| ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/d1ca5c34-53d6-4ed5-af8f-1c3a50c637dd) | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/e6e54e9a-77bb-4abf-875d-5db7b145e8f7) |



