### PR TITLE
fix(syntax): "other" in "variable.other.account"

### DIFF
--- a/syntaxes/beancount.tmLanguage
+++ b/syntaxes/beancount.tmLanguage
@@ -877,7 +877,7 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>variable.account.beancount</string>
+							<string>variable.other.account.beancount</string>
 						</dict>
 						<key>2</key>
 						<dict>


### PR DESCRIPTION
As per two guides linked in vscode scoping docs ([1](https://macromates.com/manual/en/language_grammars), [2](https://www.sublimetext.com/docs/scope_naming.html)) all other variables should be classified under `variable.other`. In practice, indeed, several themes have a specific scope for `variable.other`, see the table below.

| theme | before | after |
|--------|--------|--------|
| Github Dark | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/9825dc9a-a652-42c4-895d-d1ddaa7c3449)  | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/36b7abfe-6a4f-4870-aef3-97e5fe55f478) |
| Solarized Dark | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/2ff15530-bc57-4cda-8a33-89e0a86fddce) | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/300af9bc-5447-477e-b909-21a104005ea8) |
| Monokai Pro | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/0e8be243-eede-400b-ada8-51e42efab73d) | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/42cca380-5188-4fb7-acbb-7be29fc345bb) |
