### PR TITLE
feat(syntax): account name prefix as "variable.language"

### DIFF
--- a/syntaxes/beancount.tmLanguage
+++ b/syntaxes/beancount.tmLanguage
@@ -855,7 +855,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>constant.language.beancount</string>
+					<string>variable.language.beancount</string>
 				</dict>
 				<key>2</key>
 				<dict>


### PR DESCRIPTION
Conceptually, I find it weird that first half of account is a constant (`constant.language.*`) and the latter part of it is variable (`variable.*`). I suggest to use `variable.language` for the first part to align both sides of account consistently to the idea that accounts are visually represented as variables.

Practically, here are screenshots for various popular themes (includes #93 changes). The way how either of two colors looks together with latter part of account depends likely depends on taste, but generally I don't see nothing obviously wrong in any of cases. IMHO a general improvement is that in all cases former part of account is more different or similar compared to the date above it.

| theme | before | after |
|--------|--------|--------|
| Ayu Dark | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/a2197e6b-fe4e-42ca-8443-0db40dc9ad88) | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/ac4e3b7f-36ff-4b95-8adf-3c65bbab196f) |
| Dark (Visual Studio) | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/c4f77bf0-6ed5-4bcf-8c3e-5ee1f72b37ae) | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/abff09d3-70d7-43e4-bd15-6de5aa5ea0b5) |
| Dark Modern | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/504ce820-d409-461a-b829-853bd9f04555) | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/9fee7c09-3ecc-4560-be29-9b1ac3cf3ee9) |
| Dracula | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/2e24ebbe-9d4f-44ba-8493-2ecd05d4c044) | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/4dc04db8-62a9-4384-b6b0-66c95733d73f) |
| Github Dark | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/d52a5cad-dc8d-4bd6-b120-005c499ec677) | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/112f4ffb-c252-4c8b-82a2-bccc450c318f) |
| Monokai | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/7b5c1267-8b5a-40d8-ae7f-ce987a2f5f85) | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/6438effe-48e5-4ad5-ad85-178169529d41) |
| Monokai Pro | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/22ac60ae-8b5b-4557-a6ce-ce23b2c29c67) | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/2f5d518f-7552-4199-9458-4196f671d538) |
| Night Owl | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/5dbced33-adde-499f-8168-f9338be074f0) | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/58fc528f-386a-49fc-8c4c-937f1abdbebb) |
| One Dark | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/f203c8be-a459-4a4a-aa73-2455795ad294) | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/be8e354e-772c-44b2-abe8-bff11829ac55) |
| Winter Is Coming | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/c13bb599-2f89-4c93-8c0c-7962e2171904) | ![image](https://github.com/Lencerf/vscode-beancount/assets/7459419/883817a6-f597-4fdb-97d4-b2bb24bd24d7) |
