### PR TITLE
Add org-mode-fold to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ VSCode extension for the text-based double-entry accounting tool
    ([@vlamacko](https://github.com/Lencerf/vscode-beancount/pull/7))
 7. Region folding - use indentation
    ([#5](https://github.com/Lencerf/vscode-beancount/issues/5)), or special
-   comments ([#11](https://github.com/Lencerf/vscode-beancount/pull/11))
+   comments ([#11](https://github.com/Lencerf/vscode-beancount/pull/11)). For org-mode style folding see [vscode-org-fold](https://marketplace.visualstudio.com/items?itemName=dumbPy.vscode-org-fold)
 8. (Experimental) Use Pinyin initial letters to input existing Chinese
    narrations and payees quickly. 使用拼音首字母快速输入现有的中文受款人和描述
    。[See details](https://github.com/Lencerf/vscode-beancount/blob/master/InputMethods.md).


### PR DESCRIPTION
vscode provides an api for registering folding range provider that is [used by vscode-org-mode](https://github.com/vscode-org-mode/vscode-org-mode/blob/98f123a97eca8d0cc1d9e3f313dc2a8be8f25d46/src/extension.ts#L61) for org-mode style folding.

But since the vscode-org-mode extension hasn't been updated for a long time and has GPLV3 license which is not compatible with this repository's MIT license, I have separated the org style code folding from the above repo into a separate extension call org-mode-fold. 

Works as expected with this extension, on my testing.