### PR TITLE
Support opening files from 'include' directive by adding DocumentLinkProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,8 +113,8 @@
           "beancount with oneline plugin"
         ],
         "extensions": [
-          ".beancount",
-          ".bean"
+          ".onebeancount",
+          ".onebean"
         ],
         "configuration": "./language-configuration.json"
       }

--- a/package.json
+++ b/package.json
@@ -113,8 +113,8 @@
           "beancount with oneline plugin"
         ],
         "extensions": [
-          ".onebeancount",
-          ".onebean"
+          ".beancount",
+          ".bean"
         ],
         "configuration": "./language-configuration.json"
       }

--- a/src/documentLinkProvider.ts
+++ b/src/documentLinkProvider.ts
@@ -13,20 +13,16 @@ export default class DocumentLinkProvider implements vscode.DocumentLinkProvider
         }
 
         const links: DocumentLink[] = [];
-        // debugger;
         for (const match of text.matchAll(/include\s+"([^"]+.(?:beancount|bean))"/g)) {
             const includedFileName = match[1];
 
             const range = this.create_range(document, match);
             if (range === undefined) {
                 // Nothing matched.
-                debugger;
                 console.error("nothing matched");
                 continue;
             }
 
-            // debugger;
-            console.info('includedFileName: ', includedFileName);
             const link = new DocumentLink(range, vscode.Uri.joinPath(workspaceRootUri, includedFileName));
             link.tooltip = "Follow link";
             links.push(link);

--- a/src/documentLinkProvider.ts
+++ b/src/documentLinkProvider.ts
@@ -1,0 +1,50 @@
+import * as vscode from "vscode";
+import { DocumentLink, Range, TextDocument } from "vscode";
+import { getWorkspaceRootUri } from "./utils";
+
+export default class DocumentLinkProvider implements vscode.DocumentLinkProvider {
+    public provideDocumentLinks(document: TextDocument): vscode.DocumentLink[] {
+        const text = document.getText();
+
+        const workspaceRootUri = getWorkspaceRootUri();
+        if (workspaceRootUri === undefined) {
+            console.error('Invalid workspace root path.');
+            return [];
+        }
+
+        const links: DocumentLink[] = [];
+        // debugger;
+        for (const match of text.matchAll(/include\s+"([^"]+.(?:beancount|bean))"/g)) {
+            const includedFileName = match[1];
+
+            const range = this.create_range(document, match);
+            if (range === undefined) {
+                // Nothing matched.
+                debugger;
+                console.error("nothing matched");
+                continue;
+            }
+
+            // debugger;
+            console.info('includedFileName: ', includedFileName);
+            const link = new DocumentLink(range, vscode.Uri.joinPath(workspaceRootUri, includedFileName));
+            link.tooltip = "Follow link";
+            links.push(link);
+        }
+
+        return links;
+    }
+
+    private create_range(document: TextDocument, match: RegExpMatchArray): Range | undefined {
+        if (match.index === undefined) {
+            // nothing matched.
+            return;
+        }
+
+        // extend the range by 1 in both sides to include the quote characters.
+        const start = document.positionAt(match.index + match[0].length - match[1].length - 2);
+        const end = document.positionAt(match.index + match[0].length + 1);
+        const r = new Range(start, end);
+        return r;
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,9 +7,11 @@ import { Completer } from "./completer";
 import { Formatter } from "./formatter";
 import { runCmd } from "./utils";
 import { SymbolProvider } from "./symbolProvider";
+import DocumentLinkProvider from "./documentLinkProvider";
 
 export function activate(context: vscode.ExtensionContext) {
   const extension = new Extension(context);
+  const beancountDocumentSelector = { scheme: "file", language: "beancount" };
 
   vscode.commands.registerCommand("beancount.runFava", () =>
     extension.favaManager.openFava(true)
@@ -25,7 +27,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.languages.registerCompletionItemProvider(
-      { scheme: "file", language: "beancount" },
+      beancountDocumentSelector,
       extension.completer,
       "2",
       "#",
@@ -35,13 +37,13 @@ export function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(
     vscode.languages.registerHoverProvider(
-      { scheme: "file", language: "beancount" },
+      beancountDocumentSelector,
       extension.completer
     )
   );
   context.subscriptions.push(
     vscode.languages.registerCodeActionsProvider(
-      { scheme: "file", language: "beancount" },
+      beancountDocumentSelector,
       extension.actionProvider
     )
   );
@@ -83,13 +85,17 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.languages.registerDocumentSymbolProvider(
-      { scheme: "file", language: "beancount" },
+      beancountDocumentSelector,
       extension.symbolProvider
-    )
-  );
+    ));
+  context.subscriptions.push(
+    vscode.languages.registerDocumentLinkProvider(
+      beancountDocumentSelector,
+      extension.documentLinkProvider
+    ));
 }
 
-export function deactivate() {}
+export function deactivate() { }
 
 export class Extension {
   completer: Completer;
@@ -101,6 +107,7 @@ export class Extension {
   flagWarnings: FlagWarnings;
   context: vscode.ExtensionContext;
   symbolProvider: SymbolProvider;
+  documentLinkProvider: DocumentLinkProvider;
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
@@ -114,6 +121,7 @@ export class Extension {
     this.flagWarnings =
       vscode.workspace.getConfiguration("beancount")["flagWarnings"];
     this.symbolProvider = new SymbolProvider();
+    this.documentLinkProvider = new DocumentLinkProvider();
   }
 
   resolveToAbsolutePath(path: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { TextDocument, Uri, window, workspace } from 'vscode';
 import { spawn, SpawnOptionsWithoutStdio } from "child_process";
 
 export function runCmd(
@@ -30,4 +31,19 @@ export function pushIfEmpty<T>(array: T[], defaultValue: T): T[] {
     array.push(defaultValue);
   }
   return array;
+}
+
+export function getWorkspaceRootUri(): Uri | undefined {
+  const document = getCurrentTextDocument();
+  if (document) {
+    const fileUri = document.uri;
+    const workspaceFolder = workspace.getWorkspaceFolder(fileUri);
+    if (workspaceFolder) {
+      return workspaceFolder.uri;
+    }
+  }
+}
+
+export function getCurrentTextDocument(): TextDocument | undefined {
+  return window.activeTextEditor?.document;
 }


### PR DESCRIPTION
This PR tries to address the issue #79 by adding a new `DocumentLinkProvider` to detect file links specified by `include` directive and provide them as clickable DocumentLinks.

Demo:
![issue79-demo](https://github.com/Lencerf/vscode-beancount/assets/4214297/5282f225-5d84-4bdb-aca8-ad54effb60a8)

### Beancount-oneline & beancount conflicts
During testing, I've noticed the two languages specified in package.json `beancount` and `beancount-oneline` could have conflicts which could cause language providers (such as this DocumentLinkProvider) not working without changing the extension names of the `beancount-oneline`.

For the simplicity of this PR, I didn't fix it here, but I have opened another issue to track it.