### PR TITLE
Inlay hints - support inferring from multiple postings

### DIFF
--- a/pythonFiles/beancheck.py
+++ b/pythonFiles/beancheck.py
@@ -67,7 +67,9 @@ for entry in entries:
             if posting.meta and posting.meta.get('__automatic__', False) is True:
                 # only send the posting if more than 2 legs in txn, or multiple commodities
                 if len(entry.postings) > 2 or len(txn_commodities) > 1:
-                    automatics[posting.meta['filename']][posting.meta['lineno']] = posting.units.to_string()
+                    amounts = automatics[posting.meta['filename']].get(posting.meta['lineno'], [])
+                    amounts.append(posting.units.to_string())
+                    automatics[posting.meta['filename']][posting.meta['lineno']] = amounts
         commodities.update(txn_commodities)
     elif isinstance(entry, Open):
         accounts[entry.account] = {

--- a/src/inlayHints.ts
+++ b/src/inlayHints.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { Extension } from './extension';
 
-type Automatics = { [file: string]: { [line: string]: string } };
+type Automatics = { [file: string]: { [line: string]: [string] } };
 
 const HINT_DECO = vscode.window.createTextEditorDecorationType({
     ["after"]: {
@@ -80,7 +80,8 @@ export class HintsUpdater {
                 // get values from config
                 dotPos = vscode.workspace.getConfiguration("beancount")["separatorColumn"] - 1;
             }
-            const contentText = this.padUnits(dotPos, line.text, units);
+            const hint = units.join(", ");
+            const contentText = this.padUnits(dotPos, line.text, hint);
 
             return {
                 range: line.range,


### PR DESCRIPTION
The current implementation only includes one of the postings

Before:
<img width="533" alt="Screenshot 2025-01-26 at 4 53 54 PM" src="https://github.com/user-attachments/assets/18616546-46d4-4bfa-b7ca-b5bfcc308e06" />

After:
<img width="556" alt="Screenshot 2025-01-26 at 4 47 20 PM" src="https://github.com/user-attachments/assets/ecad93a2-7c71-4369-be47-2382ff98dcae" />
